### PR TITLE
Update _headers

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
   X-Frame-Options: DENY


### PR DESCRIPTION
Added unsafe inline to Content-Security-Policy to remedy some inline scripts and styles being blocked. Do note this is a temporary solution, as there is no user input on the website at the moment. If you want to be more secure, when user input *is* added, you'll have to remove the 'unsafe-inline' values and migrate all inline styles and scripts to external files and reference them in their place.